### PR TITLE
Feature/1.7.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Removed
 
 Latest version:
 
-* Version [1.7.4](https://github.com/marinsagovac/woocommerce-tcom-payway/archive/refs/tags/1.7.4.zip) January/2024
+* Version [1.8](https://github.com/marinsagovac/woocommerce-tcom-payway/archive/refs/tags/1.8.zip) January/2024
 
 API 2.x.x:
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Features
 * Locale support based on WP locale settings (EN/HR)
 * Multilanguage support using po/mo translation
 * Replace banner image of PayWay on checkout with smaller 250px width
+* Not needle IntAmount and IntCurrency from 1.1.2024.
 
 Removed
 * Removed woo-multi-currency support and integration
@@ -41,7 +42,7 @@ Removed
 
 Latest version:
 
-* Version [1.7.3](https://github.com/marinsagovac/woocommerce-tcom-payway/archive/refs/tags/1.7.3.zip) January/2023
+* Version [1.7.4](https://github.com/marinsagovac/woocommerce-tcom-payway/archive/refs/tags/1.7.4.zip) January/2024
 
 API 2.x.x:
 

--- a/classes/class-wc-tpayway.php
+++ b/classes/class-wc-tpayway.php
@@ -391,9 +391,6 @@ class WC_TPAYWAY extends WC_Payment_Gateway
             'acq_id' => $this->acq_id, // secret key
             'PurchaseAmt' => $order_format_value,
 
-            'IntCurrency' => 'HRK',
-            'IntAmount' => $total_amount_request * $this->ratehrkfixed,
-
             // ISO 4217
             'CurrencyCode' => 978
         );
@@ -484,8 +481,15 @@ class WC_TPAYWAY extends WC_Payment_Gateway
         global $woocommerce;
 
         // Return if is error during installation
+        // Back to homepage
         if (!isset($_POST['ShoppingCartID'])) {
-            return;
+            $text = '<html><meta charset="utf-8"><body><center>';
+            $text .= __('Redirecting...', 'tcom-payway-wc');
+            $text .= '</center><script>setTimeout(function(){ window.location.replace("' . home_url() . '"); },1500);</script></body></html>';
+            
+            echo $text;
+
+            exit;
         }
 
         if (!$_POST['Amount']) {

--- a/tcom-payway-woocommerce.php
+++ b/tcom-payway-woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce PayWay Hrvatski Telekom payment gateway
  * Plugin URI:  https://github.com/marinsagovac/woocommerce-tcom-payway
  * Description: WooCommerce PayWay Hrvatski Telekom payment gateway
- * Version:     1.7.1
+ * Version:     1.8
  * Licence:     MIT
  * License URI: https://opensource.org/licenses/MIT
  * Author:      Marin Šagovac


### PR DESCRIPTION
- remove Intl from 2024 for EUR
- fix https://github.com/marinsagovac/woocommerce-tcom-payway/issues/27