### PR TITLE
Fix Compatibility Issues with PHP 8.3 ( Issue Fixed #33 and #34 )

### DIFF
--- a/tcom-payway-woocommerce.php
+++ b/tcom-payway-woocommerce.php
@@ -11,26 +11,41 @@
  * Text Domain: tcom-payway-wc
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
+if (! defined('ABSPATH')) {
 	exit; // Exit if accessed directly
 }
 
 // Plugin directory, with trailing slash.
-if ( ! defined( 'TCOM_PAYWAY_DIR' ) ) {
-	define( 'TCOM_PAYWAY_DIR', plugin_dir_path( __FILE__ ) );
+if (! defined('TCOM_PAYWAY_DIR')) {
+	define('TCOM_PAYWAY_DIR', plugin_dir_path(__FILE__));
 }
 
 // Plugin URL, with trailing slash.
-if ( ! defined( 'TCOM_PAYWAY_URL' ) ) {
-	define( 'TCOM_PAYWAY_URL', plugin_dir_url( __FILE__ ) );
+if (! defined('TCOM_PAYWAY_URL')) {
+	define('TCOM_PAYWAY_URL', plugin_dir_url(__FILE__));
 }
 
-load_plugin_textdomain( 'tcom-payway-wc', false, trailingslashit( dirname( plugin_basename( __FILE__ ) ) ) );
+// Remove or comment out the direct call to load_plugin_textdomain
+// load_plugin_textdomain( 'tcom-payway-wc', false, trailingslashit( dirname( plugin_basename( __FILE__ ) ) ) );
+
+/**
+ * Load plugin textdomain.
+ */
+function tcom_payway_load_textdomain()
+{
+	load_plugin_textdomain(
+		'tcom-payway-wc', // Textdomain
+		false,            // Deprecated argument, set to false
+		dirname(plugin_basename(__FILE__)) . '/languages/' // Path to language files
+	);
+}
+add_action('init', 'tcom_payway_load_textdomain');
 
 add_action('plugins_loaded', 'woocommerce_tpayway_gateway', 0);
-function woocommerce_tpayway_gateway() {
+function woocommerce_tpayway_gateway()
+{
 
-	if ( ! class_exists( 'WC_Payment_Gateway' ) ) {
+	if (! class_exists('WC_Payment_Gateway')) {
 		return;
 	}
 
@@ -38,29 +53,31 @@ function woocommerce_tpayway_gateway() {
 
 	$wc = new WC_TPAYWAY();
 
-	function woocommerce_add_tpayway_gateway( $methods ) {
+	function woocommerce_add_tpayway_gateway($methods)
+	{
 		$methods[] = 'WC_TPAYWAY';
 		return $methods;
 	}
 
-	add_filter( 'woocommerce_payment_gateways', 'woocommerce_add_tpayway_gateway' );
+	add_filter('woocommerce_payment_gateways', 'woocommerce_add_tpayway_gateway');
 }
 
 global $jal_db_version;
 $jal_db_version = '0.1';
 
-function jal_install_tpayway() {
+function jal_install_tpayway()
+{
 	global $wpdb;
 	global $jal_db_version;
 
 	$table_name      = $wpdb->prefix . 'tpayway_ipg';
 	$charset_collate = '';
 
-	if ( ! empty( $wpdb->charset ) ) {
+	if (! empty($wpdb->charset)) {
 		$charset_collate = "DEFAULT CHARACTER SET {$wpdb->charset}";
 	}
 
-	if ( ! empty( $wpdb->collate ) ) {
+	if (! empty($wpdb->collate)) {
 		$charset_collate .= " COLLATE {$wpdb->collate}";
 	}
 
@@ -79,11 +96,12 @@ function jal_install_tpayway() {
 	require_once(ABSPATH . 'wp-admin/includes/upgrade.php');
 	dbDelta($sql);
 
-	add_option( 'jal_db_version', $jal_db_version );
+	add_option('jal_db_version', $jal_db_version);
 }
-register_activation_hook( __FILE__, 'jal_install_tpayway');
+register_activation_hook(__FILE__, 'jal_install_tpayway');
 
-function jal_install_data_tpayway() {
+function jal_install_data_tpayway()
+{
 	global $wpdb;
 
 	$welcome_name = 'PayWay Hrvatski Telekom';
@@ -91,14 +109,15 @@ function jal_install_data_tpayway() {
 
 	$table_name = $wpdb->prefix . 'tpayway_ipg';
 }
-register_activation_hook( __FILE__, 'jal_install_data_tpayway');
+register_activation_hook(__FILE__, 'jal_install_data_tpayway');
 
-add_filter('plugin_action_links_'.plugin_basename(__FILE__), 'jal_add_plugin_page_settings_link');
-function jal_add_plugin_page_settings_link( $links ) {
-    $links[] = '<a href="' .
-        admin_url('admin.php?page=wc-settings&tab=checkout&section=wc_tpayway') .
-        '">' . __('Settings') . '</a>';
-    return $links;
+add_filter('plugin_action_links_' . plugin_basename(__FILE__), 'jal_add_plugin_page_settings_link');
+function jal_add_plugin_page_settings_link($links)
+{
+	$links[] = '<a href="' .
+		admin_url('admin.php?page=wc-settings&tab=checkout&section=wc_tpayway') .
+		'">' . __('Settings', 'tcom-payway-wc') . '</a>';
+	return $links;
 }
 
 if (is_admin()) {


### PR DESCRIPTION
### **Overview**

This Pull Request addresses critical compatibility issues reported by customers when using the `woocommerce-tcom-payway` plugin with PHP version 8.3. The fixes ensure that the plugin operates smoothly without triggering fatal errors or notices, enhancing overall stability and user experience.

### **Fixed Issues**

1.  **\[#33\] Reported by customer on PHP 8.3** _Customer Report:_
    
    > "After a successful purchase, the following logs appeared (which hadn't before), and I'm unsure if they're related to this plugin."
    
    `[20-Nov-2024 09:27:24 UTC] id was called incorrectly. Order properties should not be accessed directly. Backtrace: ... [20-Nov-2024 09:27:24 UTC] order_key was called incorrectly. Order properties should not be accessed directly. Backtrace: ... [20-Nov-2024 09:27:24 UTC] The woocommerce_get_page_id function is deprecated since version 3.0. Replace with wc_get_page_id. [20-Nov-2024 09:27:24 UTC] The wc_get_page_id argument is deprecated since version 2.1. The "pay" and "thanks" pages are no-longer used ...`
    
2.  **\[#34\] Plugin Crash on PHP v8.3** _Customer Report:_
    
    > "When activating the `woocommerce-tcom-payway` plugin on a WordPress site running PHP version 8.3, the following fatal error occurs:
    > 
    > `Fatal error: Access level to WC_TPAYWAY::$title must be public (as in class WC_Payment_Gateway) in /path/to/plugin/classes/class-wc-tpayway.php on line 8`
    > 
    > This error prevents the website from functioning properly, displaying a critical error message to both administrators and visitors."
    

### **Detailed Description of Fixes**

1.  **Resolved Fatal Error Due to Property Visibility**
    *   **Issue:** The `WC_TPAYWAY` class had properties (e.g., `$title`) declared as `private`, which conflicted with their `public` declaration in the parent `WC_Payment_Gateway` class. PHP 8.3 enforces stricter access level rules, resulting in fatal errors.
    *   **Solution:** Changed the visibility of the affected properties from `private` to `public` to align with the parent class's visibility.
    *   **Code Changes:**
        
        `// Before private $title; // After public $title;`
        
2.  **Addressed Deprecated Order Property Access**
    *   **Issue:** Direct access to order properties like `$order->id` and `$order->order_key` is deprecated since WooCommerce version 3.0. This practice triggers notices in PHP 8.3.
    *   **Solution:** Replaced direct property accesses with WooCommerce's getter methods.
    *   **Code Changes:**
        
        `// Before 'redirect' => add_query_arg('order', $order->id, add_query_arg('key', $order->order_key, get_permalink(woocommerce_get_page_id('pay')))), // After 'redirect' => $order->get_checkout_payment_url(),`
        
3.  **Replaced Deprecated WooCommerce Functions**
    *   **Issue:** The function `woocommerce_get_page_id` is deprecated since version 3.0, and certain arguments in `wc_get_page_id` are deprecated since version 2.1.
    *   **Solution:** Updated the code to use `wc_get_page_id` appropriately and utilized methods like `$order->get_checkout_payment_url()` and `$order->get_checkout_order_received_url()` for generating valid URLs.
    *   **Code Changes:**
        
        `// Before get_permalink(woocommerce_get_page_id('pay')) // After $order->get_checkout_payment_url()`
        
4.  **Properly Hooked Textdomain Loading to Prevent Early Translation Loading**
    *   **Issue:** The `load_plugin_textdomain` function was called too early in the plugin's main file, triggering notices about incorrect translation loading timing.
    *   **Solution:** Moved the `load_plugin_textdomain` call to an `init` action hook to ensure translations are loaded at the appropriate time.
    *   **Code Changes:**
        
        `// Before (in main plugin file) load_plugin_textdomain( 'tcom-payway-wc', false, trailingslashit( dirname( plugin_basename( __FILE__ ) ) ) ); // After (in main plugin file) function tcom_payway_load_textdomain() { load_plugin_textdomain( 'tcom-payway-wc', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' ); } add_action( 'init', 'tcom_payway_load_textdomain' ); // Additionally, in the WC_TPAYWAY class: public function load_textdomain() { load_plugin_textdomain( 'tcom-payway-wc', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' ); } add_action( 'init', array( $this, 'load_textdomain' ) );`
        

### **Summary of Changes**

*   **Property Visibility Adjustments:** Changed several `private` properties to `public` within the `WC_TPAYWAY` class to comply with PHP's inheritance rules and prevent fatal errors.
*   **Deprecated Function Replacements:** Updated all instances of deprecated functions and direct property accesses to use WooCommerce's current methods and functions.
*   **Textdomain Loading Enhancement:** Ensured that translation files are loaded during the `init` action to prevent premature loading and related notices.

### **How to Test**

1.  **Environment Setup:**
    *   Ensure you have a WordPress installation with the latest versions of WordPress and WooCommerce.
    *   Set the PHP version to **8.3**.
2.  **Plugin Installation:**
    *   Install the updated `woocommerce-tcom-payway` plugin from this PR.
    *   Activate the plugin and navigate to the WooCommerce payment settings to verify the new settings link.
3.  **Testing Payment Process:**
    *   Initiate a test purchase using the PayWay Hrvatski Telekom payment gateway.
    *   Confirm that the payment process completes without triggering any fatal errors or notices.
    *   Verify that order statuses update correctly based on payment outcomes.
4.  **Review Error Logs:**
    *   Check the `wp-content/debug.log` file for any residual notices or errors related to the plugin.
    *   Ensure that no new warnings or errors appear during normal plugin operation.
5.  **Translation Verification:**
    *   Switch your site's language (if applicable) to verify that plugin translations load correctly without triggering notices.

### **Conclusion**

This PR effectively resolves the critical compatibility issues reported by customers using PHP 8.3, ensuring that the `woocommerce-tcom-payway` plugin operates seamlessly without triggering fatal errors or notices. By adhering to WooCommerce and WordPress best practices, the plugin's stability and maintainability are significantly enhanced.